### PR TITLE
docs: update README to reflect changes on sending a local message

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ curl -X POST http://localhost:8080/v1/admin/agents \
 #   }
 # }
 
-# Send a local message (will work)
+# Send a local message
 curl -X POST http://localhost:8080/v1/messages \
   -H "Content-Type: application/json" \
   -d '{


### PR DESCRIPTION
Just verified that sending a local message is suported, so update README accordingly.

``` bash
http post http://localhost:8081/v1/messages Content-Type:application/json sender=test@localhost recipients:=[\"env_agent@localhost\"] subject=\"hello\" payload:='{"message": "hello world"}' --body
{
    "message_id": "01995cad-05f4-76f9-bf0d-a71dbde3c1a8",
    "recipients": [
        {
            "address": "env_agent@localhost",
            "attempts": 1,
            "delivery_mode": "pull",
            "inbox_delivered": true,
            "local_delivery": true,
            "status": "delivered",
            "timestamp": "2025-09-18T11:54:27.188336008Z"
        }
    ],
    "status": "delivered"
}
```