### PR TITLE
feat: refactor schema registry to use database storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,9 +301,9 @@ Options:
 ##### Schema Configuration
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `AMTP_SCHEMA_REGISTRY_TYPE` | - | Schema registry type (set to `local` to enable) |
-| `AMTP_SCHEMA_REGISTRY_PATH` | - | Path to local schema registry directory |
-| `AMTP_SCHEMA_USE_LOCAL_REGISTRY` | `false` | Enable local schema registry (alternative to setting type) |
+| `AMTP_SCHEMA_REGISTRY_TYPE` | - | Schema registry type (set to `local` or `database` to enable) |
+| `AMTP_SCHEMA_REGISTRY_PATH` | - | Path to local schema registry directory (when type is `local`) |
+| `AMTP_SCHEMA_USE_LOCAL_REGISTRY` | `false` | (Deprecated) Enable local schema registry. Use `AMTP_SCHEMA_REGISTRY_TYPE=local` instead. |
 
 > ⚠️ **Security Note**: Variables marked with ⚠️ should only be used in development environments. Never enable `AMTP_DNS_ALLOW_HTTP=true` in production as it allows insecure HTTP gateway URLs.
 
@@ -354,8 +354,7 @@ export AMTP_STORAGE_DATABASE_MAX_IDLE_TIME=300
 export AMTP_METRICS_ENABLED=true
 
 # Schema management (optional - enable for schema validation)
-export AMTP_SCHEMA_REGISTRY_TYPE=local
-export AMTP_SCHEMA_REGISTRY_PATH="/var/lib/agentry/schemas"
+export AMTP_SCHEMA_REGISTRY_TYPE=database
 ```
 
 #### Development Configuration
@@ -385,7 +384,7 @@ export AMTP_LOG_FORMAT=text
 # Schema management (optional - enable for schema validation)
 export AMTP_SCHEMA_REGISTRY_TYPE=local
 export AMTP_SCHEMA_REGISTRY_PATH="/tmp/schemas"
-# Alternative: export AMTP_SCHEMA_USE_LOCAL_REGISTRY=true
+# Alternative: export AMTP_SCHEMA_REGISTRY_TYPE=database for database registry
 ```
 
 > 📝 **Development Note**: The development script `./scripts/local-dev.sh` automatically sets these variables for you.

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -53,3 +53,11 @@ storage:
     connection_string: "host=localhost port=5432 user=postgres password=postgres dbname=agentry sslmode=disable"
     max_connections: 100
     max_idle_time: 300
+
+# Schema management configuration
+schema:
+  registry_type: "database" # or "local", "http"
+  # If local, configure local_registry path
+  # local_registry:
+  #   base_path: "./schemas"
+

--- a/config/config.schema.yaml
+++ b/config/config.schema.yaml
@@ -33,7 +33,7 @@ storage:
 
 # Schema management configuration
 schema:
-  use_local_registry: true
+  registry_type: "local"
   local_registry:
     base_path: "./schemas"
     index_file: "index.json"

--- a/config/schema.example.yaml
+++ b/config/schema.example.yaml
@@ -1,10 +1,10 @@
 # AMTP Gateway Schema Configuration Example
 
 schema:
-  # Use local registry (recommended for most deployments)
-  use_local_registry: true
+  # Registry type: "local", "http", or "database"
+  registry_type: "local"
   
-  # Local registry configuration
+  # Local registry configuration (when registry_type is "local")
   local_registry:
     base_path: "./schemas"
     auto_save: true
@@ -12,7 +12,7 @@ schema:
     create_dirs: true
     backup_count: 5
   
-  # External registry configuration (if use_local_registry is false)
+  # External registry configuration (when registry_type is "http")
   registry:
     base_url: "https://schemas.example.com"
     api_key: "your-api-key"

--- a/deployment/db/03-schemas.sql
+++ b/deployment/db/03-schemas.sql
@@ -1,0 +1,16 @@
+-- Create schemas table
+CREATE TABLE IF NOT EXISTS schemas (
+    id SERIAL PRIMARY KEY,
+    domain VARCHAR(255) NOT NULL,
+    entity VARCHAR(255) NOT NULL,
+    version VARCHAR(64) NOT NULL,
+    definition JSONB NOT NULL,
+    published_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    signature VARCHAR(512),
+    checksum VARCHAR(64),
+    size BIGINT DEFAULT 0,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Create unique index on domain, entity, and version
+CREATE UNIQUE INDEX IF NOT EXISTS idx_schema_ver ON schemas (domain, entity, version);

--- a/docker/docker-compose.db-test.yml
+++ b/docker/docker-compose.db-test.yml
@@ -17,6 +17,7 @@ services:
       - AMTP_STORAGE_DATABASE_CONNECTION_STRING=host=postgres port=5432 user=postgres password=postgres dbname=agentry sslmode=disable
       - AMTP_STORAGE_DATABASE_MAX_CONNS=100
       - AMTP_STORAGE_DATABASE_MAX_IDLE_TIME=300
+      - AMTP_SCHEMA_REGISTRY_TYPE=database
     healthcheck:
       test: ["CMD", "/agentry", "--health-check"]
       interval: 30s
@@ -54,6 +55,11 @@ services:
     depends_on:
       - agentry
       - postgres
+    healthcheck:
+      test: ["CMD", "which", "curl"]
+      interval: 2s
+      timeout: 5s
+      retries: 10
 
 networks:
   default:

--- a/docker/docker-compose.domain-simulation.yml
+++ b/docker/docker-compose.domain-simulation.yml
@@ -32,8 +32,12 @@ services:
       - AMTP_LOGGING_FORMAT=text
       - AMTP_DNS_RESOLVERS=172.20.0.10:53
       - AMTP_DNS_ALLOW_HTTP=true
+      - AMTP_SCHEMA_REGISTRY_TYPE=local
+      - AMTP_SCHEMA_REGISTRY_PATH=/schemas
     ports:
       - "8080:8080"
+    volumes:
+      - /tmp/amtp-schemas:/schemas
     networks:
       amtp-network:
         aliases:
@@ -64,8 +68,14 @@ services:
       - AMTP_AUTH_REQUIRED=false
       - AMTP_LOGGING_LEVEL=debug
       - AMTP_LOGGING_FORMAT=text
+      - AMTP_DNS_RESOLVERS=172.20.0.10:53
+      - AMTP_DNS_ALLOW_HTTP=true
+      - AMTP_SCHEMA_REGISTRY_TYPE=local
+      - AMTP_SCHEMA_REGISTRY_PATH=/schemas
     ports:
       - "8081:8080"
+    volumes:
+      - /tmp/amtp-schemas:/schemas
     networks:
       amtp-network:
         aliases:
@@ -96,8 +106,14 @@ services:
       - AMTP_AUTH_REQUIRED=false
       - AMTP_LOGGING_LEVEL=debug
       - AMTP_LOGGING_FORMAT=text
+      - AMTP_DNS_RESOLVERS=172.20.0.10:53
+      - AMTP_DNS_ALLOW_HTTP=true
+      - AMTP_SCHEMA_REGISTRY_TYPE=local
+      - AMTP_SCHEMA_REGISTRY_PATH=/schemas
     ports:
       - "8082:8080"
+    volumes:
+      - /tmp/amtp-schemas:/schemas
     networks:
       amtp-network:
         aliases:
@@ -128,6 +144,11 @@ services:
       - gateway-company-a
       - gateway-company-b
       - gateway-partner
+    healthcheck:
+      test: ["CMD", "which", "curl"]
+      interval: 2s
+      timeout: 5s
+      retries: 10
 
 networks:
   amtp-network:

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -197,7 +197,7 @@ The schema framework is built with a clean, modular architecture that provides:
 ```go
 // Create schema manager with local registry
 config := schema.ManagerConfig{
-    UseLocalRegistry: true,
+    RegistryType: "local",
     LocalRegistry: schema.LocalRegistryConfig{
         BasePath:   "./schemas",
         AutoSave:   true,
@@ -219,6 +219,27 @@ if err != nil {
     log.Fatal(err)
 }
 ```
+
+### HTTP Registry Example
+
+You can configure the schema manager to use a remote HTTP registry. Set `RegistryType` to `http` and provide a `Registry` configuration with the `base_url` (and optional auth/token, timeout).
+
+YAML example:
+
+```yaml
+registry_type: "http"
+registry:
+    base_url: "https://schema-registry.example.com"
+    timeout: "15s"
+    auth_token: "your-token-here"
+```
+
+Environment variables (alternatively):
+
+- `AMTP_SCHEMA_REGISTRY_TYPE=http` or set `AMTP_SCHEMA_REGISTRY_URL`
+- `AMTP_SCHEMA_REGISTRY_URL=https://schema-registry.example.com`
+- `AMTP_SCHEMA_REGISTRY_AUTH_TOKEN=your-token-here`
+- `AMTP_SCHEMA_REGISTRY_TIMEOUT=15s`
 
 ### Schema Registration
 

--- a/internal/agents/registry.go
+++ b/internal/agents/registry.go
@@ -235,7 +235,7 @@ func (r *Registry) VerifyAPIKey(ctx context.Context, agentAddress, apiKey string
 
 // UpdateLastAccess updates the last access timestamp for an agent
 func (r *Registry) UpdateLastAccess(ctx context.Context, agentAddress string) {
-	agent, err := r.GetAgent(ctx, agentAddress)
+	agent, err := r.getAgentInternal(ctx, agentAddress)
 	if err != nil || agent == nil {
 		return
 	}

--- a/internal/schema/database_registry.go
+++ b/internal/schema/database_registry.go
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 Sen Wang
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package schema
+
+import (
+	"context"
+	"fmt"
+)
+
+// DatabaseRegistry implements RegistryClient using a SchemaStore
+type DatabaseRegistry struct {
+	store SchemaStore
+}
+
+// NewDatabaseRegistry creates a new database registry
+func NewDatabaseRegistry(store SchemaStore) *DatabaseRegistry {
+	return &DatabaseRegistry{
+		store: store,
+	}
+}
+
+// GetSchema retrieves a schema from the database
+func (r *DatabaseRegistry) GetSchema(ctx context.Context, id SchemaIdentifier) (*Schema, error) {
+	return r.store.GetSchema(ctx, id.Domain, id.Entity, id.Version)
+}
+
+// ListSchemas lists schemas from the database
+func (r *DatabaseRegistry) ListSchemas(ctx context.Context, domain string) ([]SchemaIdentifier, error) {
+	schemas, err := r.store.ListSchemas(ctx, domain)
+	if err != nil {
+		return nil, err
+	}
+
+	ids := make([]SchemaIdentifier, len(schemas))
+	for i, s := range schemas {
+		ids[i] = s.ID
+	}
+	return ids, nil
+}
+
+// RegisterOrUpdateSchema registers or updates a schema in the database
+func (r *DatabaseRegistry) RegisterOrUpdateSchema(ctx context.Context, s *Schema, meta *SchemaMetadata) error {
+	// Database registry stores schema content and selected metadata
+	// FilePath from metadata is purposefully ignored as database is the storage medium
+	return r.store.StoreSchema(ctx, s, meta)
+}
+
+// RegisterSchema registers a new schema
+func (r *DatabaseRegistry) RegisterSchema(ctx context.Context, s *Schema, meta *SchemaMetadata) error {
+	return r.store.StoreSchema(ctx, s, meta)
+}
+
+// ValidateSchema validates a schema
+func (r *DatabaseRegistry) ValidateSchema(ctx context.Context, s *Schema) error {
+	if s == nil {
+		return fmt.Errorf("schema validation failed: schema is nil")
+	}
+	return nil
+}
+
+// DeleteSchema deletes a schema from the database
+func (r *DatabaseRegistry) DeleteSchema(ctx context.Context, id SchemaIdentifier) error {
+	return r.store.DeleteSchema(ctx, id.Domain, id.Entity, id.Version)
+}
+
+// CheckCompatibility checks if a schema is compatible with another
+func (r *DatabaseRegistry) CheckCompatibility(ctx context.Context, newSchemaID, oldSchemaID SchemaIdentifier) (bool, error) {
+	return true, nil
+}
+
+// GetStats returns registry statistics
+func (r *DatabaseRegistry) GetStats() RegistryStats {
+	ctx := context.Background()
+	stats, err := r.store.GetRegistryStats(ctx)
+	if err != nil {
+		return RegistryStats{}
+	}
+	if stats == nil {
+		return RegistryStats{}
+	}
+	return *stats
+}

--- a/internal/schema/database_registry_test.go
+++ b/internal/schema/database_registry_test.go
@@ -1,0 +1,293 @@
+/*
+ * Copyright 2026 Sen Wang
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package schema
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+)
+
+// MockSchemaStore implements SchemaStore for testing
+type MockSchemaStore struct {
+	schemas map[string]*Schema
+	err     error // Force an error if set
+}
+
+func NewMockSchemaStore() *MockSchemaStore {
+	return &MockSchemaStore{
+		schemas: make(map[string]*Schema),
+	}
+}
+
+func (m *MockSchemaStore) StoreSchema(ctx context.Context, schema *Schema, meta *SchemaMetadata) error {
+	if m.err != nil {
+		return m.err
+	}
+	// Use string representation as key
+	m.schemas[schema.ID.String()] = schema
+	return nil
+}
+
+func (m *MockSchemaStore) GetSchema(ctx context.Context, domain, entity, version string) (*Schema, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	// Simple lookup based on matching fields since we don't have the full ID string
+	for _, s := range m.schemas {
+		if s.ID.Domain == domain && s.ID.Entity == entity && s.ID.Version == version {
+			return s, nil
+		}
+	}
+	return nil, ErrSchemaNotFound
+}
+
+func (m *MockSchemaStore) ListSchemas(ctx context.Context, domain string) ([]*Schema, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	var result []*Schema
+	for _, s := range m.schemas {
+		// Treat empty domain as a wildcard to return all schemas
+		if domain == "" || s.ID.Domain == domain {
+			result = append(result, s)
+		}
+	}
+	return result, nil
+}
+
+func (m *MockSchemaStore) DeleteSchema(ctx context.Context, domain, entity, version string) error {
+	if m.err != nil {
+		return m.err
+	}
+	for key, s := range m.schemas {
+		if s.ID.Domain == domain && s.ID.Entity == entity && s.ID.Version == version {
+			delete(m.schemas, key)
+			return nil
+		}
+	}
+	return ErrSchemaNotFound
+}
+
+func (m *MockSchemaStore) GetRegistryStats(ctx context.Context) (*RegistryStats, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+
+	domains := make(map[string]int)
+	entities := make(map[string]int)
+
+	for _, s := range m.schemas {
+		domains[s.ID.Domain]++
+		entities[s.ID.Entity]++
+	}
+
+	return &RegistryStats{
+		TotalSchemas: len(m.schemas),
+		Domains:      domains,
+		Entities:     entities,
+	}, nil
+}
+
+func TestDatabaseRegistry_RegisterAndGet(t *testing.T) {
+	mockStore := NewMockSchemaStore()
+	registry := NewDatabaseRegistry(mockStore)
+	ctx := context.Background()
+
+	schema := &Schema{
+		ID: SchemaIdentifier{
+			Domain:  "test",
+			Entity:  "user",
+			Version: "v1",
+			Raw:     "agntcy:test.user.v1",
+		},
+		Definition:  json.RawMessage(`{"type":"object"}`),
+		PublishedAt: time.Now(),
+	}
+
+	// Test RegisterSchema
+	err := registry.RegisterSchema(ctx, schema, nil)
+	if err != nil {
+		t.Errorf("RegisterSchema failed: %v", err)
+	}
+
+	// Test GetSchema
+	retrieved, err := registry.GetSchema(ctx, schema.ID)
+	if err != nil {
+		t.Errorf("GetSchema failed: %v", err)
+	}
+	if retrieved == nil {
+		t.Fatal("retrieved schema is nil")
+	}
+	if retrieved.ID.String() != schema.ID.String() {
+		t.Errorf("expected ID %s, got %s", schema.ID.String(), retrieved.ID.String())
+	}
+
+	// Test RegisterOrUpdateSchema
+	schema.Definition = json.RawMessage(`{"type":"string"}`)
+	err = registry.RegisterOrUpdateSchema(ctx, schema, nil)
+	if err != nil {
+		t.Errorf("RegisterOrUpdateSchema failed: %v", err)
+	}
+
+	updated, err := registry.GetSchema(ctx, schema.ID)
+	if err != nil {
+		t.Errorf("GetSchema failed after update: %v", err)
+	}
+	if string(updated.Definition) != string(schema.Definition) {
+		t.Errorf("schema definition mismatch after update")
+	}
+}
+
+func TestDatabaseRegistry_ListSchemas(t *testing.T) {
+	mockStore := NewMockSchemaStore()
+	registry := NewDatabaseRegistry(mockStore)
+	ctx := context.Background()
+
+	s1 := &Schema{ID: SchemaIdentifier{Domain: "d1", Entity: "e1", Version: "v1", Raw: "agntcy:d1.e1.v1"}}
+	s2 := &Schema{ID: SchemaIdentifier{Domain: "d1", Entity: "e2", Version: "v1", Raw: "agntcy:d1.e2.v1"}}
+	s3 := &Schema{ID: SchemaIdentifier{Domain: "d2", Entity: "e1", Version: "v1", Raw: "agntcy:d2.e1.v1"}}
+
+	registry.RegisterSchema(ctx, s1, nil)
+	registry.RegisterSchema(ctx, s2, nil)
+	registry.RegisterSchema(ctx, s3, nil)
+
+	list, err := registry.ListSchemas(ctx, "d1")
+	if err != nil {
+		t.Fatalf("ListSchemas failed: %v", err)
+	}
+	if len(list) != 2 {
+		t.Errorf("expected 2 schemas for domain d1, got %d", len(list))
+	}
+}
+
+func TestDatabaseRegistry_DeleteSchema(t *testing.T) {
+	mockStore := NewMockSchemaStore()
+	registry := NewDatabaseRegistry(mockStore)
+	ctx := context.Background()
+
+	id := SchemaIdentifier{Domain: "d1", Entity: "e1", Version: "v1", Raw: "agntcy:d1.e1.v1"}
+	s1 := &Schema{ID: id}
+	registry.RegisterSchema(ctx, s1, nil)
+
+	if err := registry.DeleteSchema(ctx, id); err != nil {
+		t.Errorf("DeleteSchema failed: %v", err)
+	}
+
+	_, err := registry.GetSchema(ctx, id)
+	if err != ErrSchemaNotFound {
+		t.Errorf("expected ErrSchemaNotFound after delete, got %v", err)
+	}
+}
+
+func TestDatabaseRegistry_StoreErrors(t *testing.T) {
+	mockStore := NewMockSchemaStore()
+	mockErr := errors.New("db error")
+	mockStore.err = mockErr
+
+	registry := NewDatabaseRegistry(mockStore)
+	ctx := context.Background()
+
+	s1 := &Schema{ID: SchemaIdentifier{Domain: "d1", Entity: "e1", Version: "v1", Raw: "agntcy:d1.e1.v1"}}
+
+	if err := registry.RegisterSchema(ctx, s1, nil); err != mockErr {
+		t.Errorf("expected error %v, got %v", mockErr, err)
+	}
+
+	if _, err := registry.GetSchema(ctx, s1.ID); err != mockErr {
+		t.Errorf("expected error %v, got %v", mockErr, err)
+	}
+
+	if _, err := registry.ListSchemas(ctx, "d1"); err != mockErr {
+		t.Errorf("expected error %v, got %v", mockErr, err)
+	}
+
+	if err := registry.DeleteSchema(ctx, s1.ID); err != mockErr {
+		t.Errorf("expected error %v, got %v", mockErr, err)
+	}
+}
+
+func TestDatabaseRegistry_OtherMethods(t *testing.T) {
+	registry := NewDatabaseRegistry(NewMockSchemaStore())
+	ctx := context.Background()
+
+	// CheckCompatibility
+	compat, err := registry.CheckCompatibility(ctx, SchemaIdentifier{}, SchemaIdentifier{})
+	if err != nil {
+		t.Errorf("CheckCompatibility returned error: %v", err)
+	}
+	if !compat {
+		t.Errorf("CheckCompatibility expected true by default")
+	}
+
+	// ValidateSchema (nil)
+	if err := registry.ValidateSchema(ctx, nil); err == nil {
+		t.Error("ValidateSchema(nil) expected error")
+	}
+
+	// ValidateSchema (non-nil)
+	if err := registry.ValidateSchema(ctx, &Schema{}); err != nil {
+		t.Errorf("ValidateSchema(struct) unexpected error: %v", err)
+	}
+
+	// GetStats
+	stats := registry.GetStats()
+	if stats.TotalSchemas != 0 {
+		t.Errorf("GetStats expected 0 TotalSchemas, got %d", stats.TotalSchemas)
+	}
+}
+
+func TestDatabaseRegistry_GetStatsCounts(t *testing.T) {
+	mockStore := NewMockSchemaStore()
+	registry := NewDatabaseRegistry(mockStore)
+	ctx := context.Background()
+
+	s1 := &Schema{ID: SchemaIdentifier{Domain: "d1", Entity: "e1", Version: "v1", Raw: "agntcy:d1.e1.v1"}}
+	s2 := &Schema{ID: SchemaIdentifier{Domain: "d1", Entity: "e2", Version: "v1", Raw: "agntcy:d1.e2.v1"}}
+	s3 := &Schema{ID: SchemaIdentifier{Domain: "d2", Entity: "e1", Version: "v1", Raw: "agntcy:d2.e1.v1"}}
+
+	if err := registry.RegisterSchema(ctx, s1, nil); err != nil {
+		t.Fatalf("failed to register s1: %v", err)
+	}
+	if err := registry.RegisterSchema(ctx, s2, nil); err != nil {
+		t.Fatalf("failed to register s2: %v", err)
+	}
+	if err := registry.RegisterSchema(ctx, s3, nil); err != nil {
+		t.Fatalf("failed to register s3: %v", err)
+	}
+
+	stats := registry.GetStats()
+	if stats.TotalSchemas != 3 {
+		t.Errorf("expected TotalSchemas 3, got %d", stats.TotalSchemas)
+	}
+
+	if stats.Domains["d1"] != 2 {
+		t.Errorf("expected domain d1 count 2, got %d", stats.Domains["d1"])
+	}
+	if stats.Domains["d2"] != 1 {
+		t.Errorf("expected domain d2 count 1, got %d", stats.Domains["d2"])
+	}
+
+	if stats.Entities["e1"] != 2 {
+		t.Errorf("expected entity e1 count 2, got %d", stats.Entities["e1"])
+	}
+	if stats.Entities["e2"] != 1 {
+		t.Errorf("expected entity e2 count 1, got %d", stats.Entities["e2"])
+	}
+}

--- a/internal/schema/interfaces.go
+++ b/internal/schema/interfaces.go
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Sen Wang
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package schema
+
+import (
+	"context"
+	"errors"
+)
+
+var (
+	// ErrSchemaNotFound is returned when a requested schema is not found
+	ErrSchemaNotFound = errors.New("schema not found")
+)
+
+// SchemaStore defines the interface for schema storage operations
+type SchemaStore interface {
+	// StoreSchema stores a schema in the registry
+	StoreSchema(ctx context.Context, schema *Schema, meta *SchemaMetadata) error
+
+	// GetSchema retrieves a schema from the registry
+	GetSchema(ctx context.Context, domain, entity, version string) (*Schema, error)
+
+	// ListSchemas lists schemas for a domain
+	ListSchemas(ctx context.Context, domain string) ([]*Schema, error)
+
+	// DeleteSchema deletes a schema from the registry
+	DeleteSchema(ctx context.Context, domain, entity, version string) error
+
+	// GetRegistryStats retrieves registry statistics
+	GetRegistryStats(ctx context.Context) (*RegistryStats, error)
+}

--- a/internal/schema/local_registry.go
+++ b/internal/schema/local_registry.go
@@ -605,9 +605,4 @@ func (lr *LocalRegistry) checkSchemaCompatibility(current, new *Schema) bool {
 	return true
 }
 
-// RegistryStats represents registry statistics
-type RegistryStats struct {
-	TotalSchemas int            `json:"total_schemas"`
-	Domains      map[string]int `json:"domains"`
-	Entities     map[string]int `json:"entities"`
-}
+

--- a/internal/schema/manager_test.go
+++ b/internal/schema/manager_test.go
@@ -42,7 +42,7 @@ func TestNewManager(t *testing.T) {
 		{
 			name: "with local registry",
 			config: ManagerConfig{
-				UseLocalRegistry: true,
+				RegistryType: "local",
 				LocalRegistry: LocalRegistryConfig{
 					BasePath:   tempDir,
 					CreateDirs: true,
@@ -71,7 +71,7 @@ func TestNewManager(t *testing.T) {
 		{
 			name: "with HTTP registry",
 			config: ManagerConfig{
-				UseLocalRegistry: false,
+				RegistryType: "http",
 				Registry: RegistryConfig{
 					BaseURL: "https://registry.example.com",
 				},
@@ -87,7 +87,6 @@ func TestNewManager(t *testing.T) {
 		{
 			name: "with mock registry (no config)",
 			config: ManagerConfig{
-				UseLocalRegistry: false,
 				Cache: CacheConfig{
 					Type: "memory",
 				},
@@ -97,7 +96,6 @@ func TestNewManager(t *testing.T) {
 		{
 			name: "invalid cache type",
 			config: ManagerConfig{
-				UseLocalRegistry: false,
 				Cache: CacheConfig{
 					Type: "invalid",
 				},
@@ -164,7 +162,6 @@ func TestNewManager(t *testing.T) {
 
 func TestManager_GetRegistry(t *testing.T) {
 	config := ManagerConfig{
-		UseLocalRegistry: false,
 		Cache: CacheConfig{
 			Type: "memory",
 		},
@@ -188,7 +185,6 @@ func TestManager_GetRegistry(t *testing.T) {
 
 func TestManager_ValidateMessage_NoSchema(t *testing.T) {
 	config := ManagerConfig{
-		UseLocalRegistry: false,
 		Cache: CacheConfig{
 			Type: "memory",
 		},
@@ -234,7 +230,6 @@ func TestManager_ValidateMessage_NoSchema(t *testing.T) {
 
 func TestManager_ValidateMessage_InvalidSchemaID(t *testing.T) {
 	config := ManagerConfig{
-		UseLocalRegistry: false,
 		Cache: CacheConfig{
 			Type: "memory",
 		},
@@ -287,7 +282,7 @@ func TestManager_ValidateMessage_Success(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	config := ManagerConfig{
-		UseLocalRegistry: true,
+		RegistryType: "local",
 		LocalRegistry: LocalRegistryConfig{
 			BasePath:   tempDir,
 			CreateDirs: true,
@@ -378,7 +373,7 @@ func TestManager_ValidateMessage_WithNegotiation(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	config := ManagerConfig{
-		UseLocalRegistry: true,
+		RegistryType: "local",
 		LocalRegistry: LocalRegistryConfig{
 			BasePath:   tempDir,
 			CreateDirs: true,
@@ -479,7 +474,7 @@ func TestManager_GetSchema(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	config := ManagerConfig{
-		UseLocalRegistry: true,
+		RegistryType: "local",
 		LocalRegistry: LocalRegistryConfig{
 			BasePath:   tempDir,
 			CreateDirs: true,
@@ -532,7 +527,7 @@ func TestManager_ListSchemas(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	config := ManagerConfig{
-		UseLocalRegistry: true,
+		RegistryType: "local",
 		LocalRegistry: LocalRegistryConfig{
 			BasePath:   tempDir,
 			CreateDirs: true,
@@ -597,7 +592,7 @@ func TestManager_UpdateSchema(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	config := ManagerConfig{
-		UseLocalRegistry: true,
+		RegistryType: "local",
 		LocalRegistry: LocalRegistryConfig{
 			BasePath:   tempDir,
 			CreateDirs: true,
@@ -660,7 +655,7 @@ func TestManager_DeleteSchema(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	config := ManagerConfig{
-		UseLocalRegistry: true,
+		RegistryType: "local",
 		LocalRegistry: LocalRegistryConfig{
 			BasePath:   tempDir,
 			CreateDirs: true,
@@ -721,7 +716,7 @@ func TestManager_CheckCompatibility(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	config := ManagerConfig{
-		UseLocalRegistry: true,
+		RegistryType: "local",
 		LocalRegistry: LocalRegistryConfig{
 			BasePath:   tempDir,
 			CreateDirs: true,
@@ -782,7 +777,6 @@ func TestManager_CheckCompatibility(t *testing.T) {
 
 func TestManager_ValidatePayload(t *testing.T) {
 	config := ManagerConfig{
-		UseLocalRegistry: false,
 		Cache: CacheConfig{
 			Type: "memory",
 		},
@@ -813,7 +807,6 @@ func TestManager_ValidatePayload(t *testing.T) {
 
 func TestManager_ClearCache(t *testing.T) {
 	config := ManagerConfig{
-		UseLocalRegistry: false,
 		Cache: CacheConfig{
 			Type: "memory",
 		},
@@ -835,7 +828,6 @@ func TestManager_ClearCache(t *testing.T) {
 
 func TestManager_GetStats(t *testing.T) {
 	config := ManagerConfig{
-		UseLocalRegistry: false,
 		Cache: CacheConfig{
 			Type: "memory",
 		},
@@ -871,7 +863,6 @@ func TestManager_GetStats(t *testing.T) {
 
 func TestManager_Shutdown(t *testing.T) {
 	config := ManagerConfig{
-		UseLocalRegistry: false,
 		Cache: CacheConfig{
 			Type: "memory",
 		},
@@ -892,7 +883,6 @@ func TestManager_Shutdown(t *testing.T) {
 
 func TestManager_ValidationWithErrorReporting(t *testing.T) {
 	config := ManagerConfig{
-		UseLocalRegistry: false,
 		Cache: CacheConfig{
 			Type: "memory",
 		},
@@ -956,7 +946,6 @@ func TestManagerConfig_DefaultValues(t *testing.T) {
 
 func TestManager_EdgeCases(t *testing.T) {
 	config := ManagerConfig{
-		UseLocalRegistry: false,
 		Cache: CacheConfig{
 			Type: "memory",
 		},

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -59,6 +59,13 @@ type ValidationError struct {
 	Value   interface{} `json:"value,omitempty"`
 }
 
+// RegistryStats represents registry statistics
+type RegistryStats struct {
+	TotalSchemas int            `json:"total_schemas"`
+	Domains      map[string]int `json:"domains"`
+	Entities     map[string]int `json:"entities"`
+}
+
 // RegistryClient defines the interface for schema registry operations
 type RegistryClient interface {
 	// GetSchema retrieves a schema by identifier

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -421,6 +421,7 @@ func (s *Server) handleListSchemas(c *gin.Context) {
 	}
 
 	pattern := c.Query("pattern")
+
 	schemas, err := s.schemaManager.GetRegistry().ListSchemas(c.Request.Context(), pattern)
 	if err != nil {
 		s.respondWithError(c, http.StatusInternalServerError, "SCHEMA_LIST_FAILED",

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -209,7 +209,7 @@ func TestNew_WithSchema(t *testing.T) {
 			RequireAuth: false,
 		},
 		Schema: &schema.ManagerConfig{
-			UseLocalRegistry: true,
+			RegistryType: "local",
 			LocalRegistry: schema.LocalRegistryConfig{
 				BasePath:   tempDir,
 				IndexFile:  "index.json",
@@ -319,7 +319,7 @@ func TestIntegration_EnvToSchemaRegistration(t *testing.T) {
 	// We need to call the internal loadFromEnv function, but since it's not exported,
 	// we'll simulate the environment variable loading by creating the schema config directly
 	cfg.Schema = &schema.ManagerConfig{
-		UseLocalRegistry: true,
+		RegistryType: "local",
 		LocalRegistry: schema.LocalRegistryConfig{
 			BasePath:   tempDir,
 			IndexFile:  "index.json",

--- a/internal/storage/database_models.go
+++ b/internal/storage/database_models.go
@@ -159,6 +159,20 @@ func (m *Message) SetCoordination(coordination *types.CoordinationConfig) error 
 	return nil
 }
 
+// Schema model for persistence
+type Schema struct {
+	ID          uint           `gorm:"primarykey" json:"-"`
+	Domain      string         `gorm:"size:255;not null;uniqueIndex:idx_schema_ver" json:"domain"`
+	Entity      string         `gorm:"size:255;not null;uniqueIndex:idx_schema_ver" json:"entity"`
+	Version     string         `gorm:"size:64;not null;uniqueIndex:idx_schema_ver" json:"version"`
+	Definition  datatypes.JSON `gorm:"type:jsonb;not null" json:"definition"`
+	PublishedAt time.Time      `gorm:"type:timestamptz" json:"published_at"`
+	Signature   string         `gorm:"size:512" json:"signature"`
+	Checksum    string         `gorm:"size:64" json:"checksum"`
+	Size        int64          `gorm:"not null;default:0" json:"size"`
+	UpdatedAt   time.Time      `gorm:"type:timestamptz;default:CURRENT_TIMESTAMP" json:"updated_at"`
+}
+
 // TableName specify table name
 func (Message) TableName() string {
 	return "messages"
@@ -170,4 +184,8 @@ func (MessageStatus) TableName() string {
 
 func (RecipientStatus) TableName() string {
 	return "recipient_statuses"
+}
+
+func (Schema) TableName() string {
+	return "schemas"
 }

--- a/internal/storage/database_schema.go
+++ b/internal/storage/database_schema.go
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2026 Sen Wang
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package storage
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"github.com/amtp-protocol/agentry/internal/schema"
+	"gorm.io/datatypes"
+	"gorm.io/gorm"
+)
+
+// StoreSchema stores a schema in the database
+func (s *DatabaseStorage) StoreSchema(ctx context.Context, sc *schema.Schema, meta *schema.SchemaMetadata) error {
+	model := Schema{
+		Domain:      sc.ID.Domain,
+		Entity:      sc.ID.Entity,
+		Version:     sc.ID.Version,
+		Definition:  datatypes.JSON(sc.Definition),
+		PublishedAt: sc.PublishedAt,
+		Signature:   sc.Signature,
+	}
+
+	if meta != nil {
+		model.Checksum = meta.Checksum
+		model.Size = meta.Size
+		// Intentionally ignoring FilePath as database is source of truth
+		// Using database timestamps instead of meta timestamps to reflect storage time
+	}
+
+	result := s.db.WithContext(ctx).Create(&model)
+	return result.Error
+}
+
+// GetSchema retrieves a schema from the database
+func (s *DatabaseStorage) GetSchema(ctx context.Context, domain, entity, version string) (*schema.Schema, error) {
+	var model Schema
+	result := s.db.WithContext(ctx).Where("domain = ? AND entity = ? AND version = ?", domain, entity, version).First(&model)
+
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, schema.ErrSchemaNotFound
+		}
+		return nil, result.Error
+	}
+
+	return toSchemaDomain(&model), nil
+}
+
+// ListSchemas lists schemas for a domain
+func (s *DatabaseStorage) ListSchemas(ctx context.Context, domain string) ([]*schema.Schema, error) {
+	var models []Schema
+	var result *gorm.DB
+	if domain == "" {
+		// empty domain => return all schemas
+		result = s.db.WithContext(ctx).Find(&models)
+	} else {
+		result = s.db.WithContext(ctx).Where("domain = ?", domain).Find(&models)
+	}
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	schemas := make([]*schema.Schema, len(models))
+	for i, m := range models {
+		schemas[i] = toSchemaDomain(&m)
+	}
+	return schemas, nil
+}
+
+// DeleteSchema deletes a schema from the database
+func (s *DatabaseStorage) DeleteSchema(ctx context.Context, domain, entity, version string) error {
+	result := s.db.WithContext(ctx).Where("domain = ? AND entity = ? AND version = ?", domain, entity, version).Delete(&Schema{})
+	return result.Error
+}
+
+// GetRegistryStats retrieves registry statistics using optimized database queries
+func (s *DatabaseStorage) GetRegistryStats(ctx context.Context) (*schema.RegistryStats, error) {
+	var total int64
+	if err := s.db.WithContext(ctx).Model(&Schema{}).Count(&total).Error; err != nil {
+		return nil, err
+	}
+
+	var domainCounts []struct {
+		Domain string
+		Count  int
+	}
+	if err := s.db.WithContext(ctx).Model(&Schema{}).Select("domain, count(*) as count").Group("domain").Scan(&domainCounts).Error; err != nil {
+		return nil, err
+	}
+
+	var entityCounts []struct {
+		Entity string
+		Count  int
+	}
+	if err := s.db.WithContext(ctx).Model(&Schema{}).Select("entity, count(*) as count").Group("entity").Scan(&entityCounts).Error; err != nil {
+		return nil, err
+	}
+
+	stats := &schema.RegistryStats{
+		TotalSchemas: int(total),
+		Domains:      make(map[string]int),
+		Entities:     make(map[string]int),
+	}
+
+	for _, d := range domainCounts {
+		stats.Domains[d.Domain] = d.Count
+	}
+	for _, e := range entityCounts {
+		stats.Entities[e.Entity] = e.Count
+	}
+
+	return stats, nil
+}
+
+func toSchemaDomain(m *Schema) *schema.Schema {
+	return &schema.Schema{
+		ID: schema.SchemaIdentifier{
+			Domain:  m.Domain,
+			Entity:  m.Entity,
+			Version: m.Version,
+		},
+		Definition:  json.RawMessage(m.Definition),
+		PublishedAt: m.PublishedAt,
+		Signature:   m.Signature,
+	}
+}

--- a/internal/storage/database_schema_test.go
+++ b/internal/storage/database_schema_test.go
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2026 Sen Wang
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package storage
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/amtp-protocol/agentry/internal/schema"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+func TestDatabaseStorage_StoreSchema(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	gormDB, err := gorm.Open(postgres.New(postgres.Config{
+		Conn: db,
+	}), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("failed to open gorm connection: %v", err)
+	}
+
+	storage := &DatabaseStorage{db: gormDB}
+	ctx := context.Background()
+
+	testSchema := &schema.Schema{
+		ID: schema.SchemaIdentifier{
+			Domain:  "test",
+			Entity:  "user",
+			Version: "v1",
+		},
+		Definition:  json.RawMessage(`{"type":"object"}`),
+		PublishedAt: time.Now(),
+		Signature:   "sig",
+	}
+
+	// Definition is stored as datatypes.JSON which implements Valuer interface
+	// For Postgres, it might be marshaled to []byte or string depending on driver
+	// The error message indicated it was receiving a string
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(`INSERT INTO "schemas"`).
+		WithArgs(testSchema.ID.Domain, testSchema.ID.Entity, testSchema.ID.Version, string(testSchema.Definition), sqlmock.AnyArg(), testSchema.Signature, sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
+	mock.ExpectCommit()
+
+	err = storage.StoreSchema(ctx, testSchema, nil)
+	if err != nil {
+		t.Errorf("StoreSchema failed: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("expectations not met: %v", err)
+	}
+}
+
+func TestDatabaseStorage_GetSchema(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	gormDB, err := gorm.Open(postgres.New(postgres.Config{
+		Conn: db,
+	}), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("failed to open gorm connection: %v", err)
+	}
+
+	storage := &DatabaseStorage{db: gormDB}
+	ctx := context.Background()
+
+	mock.ExpectQuery(`SELECT \* FROM "schemas" WHERE domain = \$1 AND entity = \$2 AND version = \$3 ORDER BY "schemas"."id" LIMIT \$4`).
+		WithArgs("test", "user", "v1", 1).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "domain", "entity", "version", "definition", "signature"}).
+			AddRow(1, "test", "user", "v1", []byte(`{"type":"object"}`), "sig"))
+
+	s, err := storage.GetSchema(ctx, "test", "user", "v1")
+	if err != nil {
+		t.Errorf("GetSchema failed: %v", err)
+	}
+	if s == nil {
+		t.Fatal("returned schema is nil")
+	}
+	if s.ID.Domain != "test" {
+		t.Errorf("expected domain test, got %s", s.ID.Domain)
+	}
+
+	// Test Not Found
+	mock.ExpectQuery(`SELECT \* FROM "schemas"`).
+		WillReturnError(gorm.ErrRecordNotFound)
+
+	_, err = storage.GetSchema(ctx, "test", "user", "v2")
+	if err != schema.ErrSchemaNotFound {
+		t.Errorf("expected ErrSchemaNotFound, got %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("expectations not met: %v", err)
+	}
+}
+
+func TestDatabaseStorage_ListSchemas(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	gormDB, err := gorm.Open(postgres.New(postgres.Config{
+		Conn: db,
+	}), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("failed to open gorm connection: %v", err)
+	}
+
+	storage := &DatabaseStorage{db: gormDB}
+	ctx := context.Background()
+
+	mock.ExpectQuery(`SELECT \* FROM "schemas" WHERE domain = \$1`).
+		WithArgs("test").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "domain", "entity", "version", "definition"}).
+			AddRow(1, "test", "user", "v1", []byte(`{}`)).
+			AddRow(2, "test", "order", "v1", []byte(`{}`)))
+
+	list, err := storage.ListSchemas(ctx, "test")
+	if err != nil {
+		t.Errorf("ListSchemas failed: %v", err)
+	}
+	if len(list) != 2 {
+		t.Errorf("expected 2 schemas, got %d", len(list))
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("expectations not met: %v", err)
+	}
+}
+
+func TestDatabaseStorage_ListSchemas_AllDomains(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	gormDB, err := gorm.Open(postgres.New(postgres.Config{
+		Conn: db,
+	}), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("failed to open gorm connection: %v", err)
+	}
+
+	storage := &DatabaseStorage{db: gormDB}
+	ctx := context.Background()
+
+	mock.ExpectQuery(`SELECT \* FROM "schemas"`).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "domain", "entity", "version", "definition"}).
+			AddRow(1, "test", "user", "v1", []byte(`{}`)).
+			AddRow(2, "other", "order", "v1", []byte(`{}`)))
+
+	list, err := storage.ListSchemas(ctx, "")
+	if err != nil {
+		t.Errorf("ListSchemas(all) failed: %v", err)
+	}
+	if len(list) != 2 {
+		t.Errorf("expected 2 schemas, got %d", len(list))
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("expectations not met: %v", err)
+	}
+}
+
+func TestDatabaseStorage_DeleteSchema(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	gormDB, err := gorm.Open(postgres.New(postgres.Config{
+		Conn: db,
+	}), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("failed to open gorm connection: %v", err)
+	}
+
+	storage := &DatabaseStorage{db: gormDB}
+	ctx := context.Background()
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`DELETE FROM "schemas" WHERE domain = \$1 AND entity = \$2 AND version = \$3`).
+		WithArgs("test", "user", "v1").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	err = storage.DeleteSchema(ctx, "test", "user", "v1")
+	if err != nil {
+		t.Errorf("DeleteSchema failed: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("expectations not met: %v", err)
+	}
+}

--- a/internal/storage/memory.go
+++ b/internal/storage/memory.go
@@ -387,7 +387,9 @@ func (ms *MemoryStorage) CreateAgent(ctx context.Context, agent *agents.LocalAge
 		return fmt.Errorf("agent already exists: %s", agent.Address)
 	}
 
-	ms.agents[agent.Address] = agent
+	// Store a copy to prevent external modifications (like API key restoration) from affecting storage
+	agentCopy := *agent
+	ms.agents[agent.Address] = &agentCopy
 	return nil
 }
 
@@ -420,7 +422,9 @@ func (ms *MemoryStorage) UpdateAgent(ctx context.Context, agent *agents.LocalAge
 		return fmt.Errorf("agent not found: %s", agent.Address)
 	}
 
-	ms.agents[agent.Address] = agent
+	// Store a copy to prevent external modifications from affecting storage
+	agentCopy := *agent
+	ms.agents[agent.Address] = &agentCopy
 	return nil
 }
 

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -75,8 +75,8 @@ start_services() {
     local attempt=1
 
     while [ $attempt -le $max_attempts ]; do
-        if docker-compose -f "$compose_file" ps | grep -q "healthy"; then
-            local healthy_count=$(docker-compose -f "$compose_file" ps | grep -c "healthy" || echo "0")
+        if docker-compose -f "$compose_file" ps | grep -q "(healthy)"; then
+            local healthy_count=$(docker-compose -f "$compose_file" ps | grep -c "(healthy)" || echo "0")
             if [ "$healthy_count" -ge "$expected_healthy_count" ]; then
                 log_success "All services are healthy!"
                 break


### PR DESCRIPTION
- Implement persistent schema storage using DatabaseStorage
- Update configuration to support registry_type: 'local' | 'database' | 'http'
- Add SQL migration file for schema tables
- Add unit tests for database schema storage and registry
- Add fvt for database schema storage and registry
- Refine ./scripts/test-simulation-docker.sh