### PR TITLE
Hoist hot-path regex compilations to package scope

### DIFF
--- a/internal/agents/registry.go
+++ b/internal/agents/registry.go
@@ -350,6 +350,10 @@ func (r *Registry) validateSupportedSchemas(ctx context.Context, schemas []strin
 	return nil
 }
 
+// schemaExactRegex matches an exact (non-wildcard) AGNTCY schema identifier:
+// agntcy:domain.entity.version
+var schemaExactRegex = regexp.MustCompile(`^agntcy:[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+\.v[0-9]+$`)
+
 // validateSchemaFormat validates the basic format of a schema identifier
 func (r *Registry) validateSchemaFormat(schemaStr string) error {
 	// Must start with agntcy:
@@ -376,8 +380,7 @@ func (r *Registry) validateSchemaFormat(schemaStr string) error {
 	// For exact schemas (not wildcards), validate full format
 	if !strings.HasSuffix(schemaStr, "*") {
 		// Should match: agntcy:domain.entity.version
-		schemaRegex := regexp.MustCompile(`^agntcy:[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+\.v[0-9]+$`)
-		if !schemaRegex.MatchString(schemaStr) {
+		if !schemaExactRegex.MatchString(schemaStr) {
 			return fmt.Errorf("schema must match format agntcy:domain.entity.version")
 		}
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -352,6 +352,9 @@ func (c *Config) validate() error {
 }
 
 // validateDomain validates the server domain configuration
+// domainRegex validates DNS domain name format.
+var domainRegex = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)*$`)
+
 func (c *Config) validateDomain() error {
 	domain := strings.TrimSpace(c.Server.Domain)
 	if domain == "" {
@@ -388,7 +391,6 @@ func (c *Config) validateDomain() error {
 	}
 
 	// Validate domain format using regex (after specific checks)
-	domainRegex := regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)*$`)
 	if !domainRegex.MatchString(domain) {
 		return fmt.Errorf("invalid domain format: %s", domain)
 	}

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -489,6 +489,12 @@ func ExtractDomain(email string) string {
 	return parts[1]
 }
 
+// gatewayURLRegex matches an HTTP or HTTPS gateway URL.
+var gatewayURLRegex = regexp.MustCompile(`^https?://[a-zA-Z0-9.-]+(?::[0-9]+)?(?:/.*)?$`)
+
+// gatewayHTTPSURLRegex matches an HTTPS-only gateway URL.
+var gatewayHTTPSURLRegex = regexp.MustCompile(`^https://[a-zA-Z0-9.-]+(?::[0-9]+)?(?:/.*)?$`)
+
 // ValidateGatewayURL validates that a gateway URL is properly formatted
 func ValidateGatewayURL(url string, allowHTTP bool) error {
 	if allowHTTP {
@@ -498,8 +504,7 @@ func ValidateGatewayURL(url string, allowHTTP bool) error {
 		}
 
 		// Validate HTTP or HTTPS URL format
-		urlRegex := regexp.MustCompile(`^https?://[a-zA-Z0-9.-]+(?::[0-9]+)?(?:/.*)?$`)
-		if !urlRegex.MatchString(url) {
+		if !gatewayURLRegex.MatchString(url) {
 			return fmt.Errorf("invalid gateway URL format")
 		}
 	} else {
@@ -509,8 +514,7 @@ func ValidateGatewayURL(url string, allowHTTP bool) error {
 		}
 
 		// Basic HTTPS URL validation
-		urlRegex := regexp.MustCompile(`^https://[a-zA-Z0-9.-]+(?::[0-9]+)?(?:/.*)?$`)
-		if !urlRegex.MatchString(url) {
+		if !gatewayHTTPSURLRegex.MatchString(url) {
 			return fmt.Errorf("invalid gateway URL format")
 		}
 	}

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -117,6 +117,9 @@ type Cache interface {
 	Clear(ctx context.Context) error
 }
 
+// schemaRegex matches the AGNTCY schema format: agntcy:domain.entity.version
+var schemaRegex = regexp.MustCompile(`^agntcy:([a-zA-Z0-9_-]+)\.([a-zA-Z0-9_-]+)\.(v[0-9]+)$`)
+
 // ParseSchemaIdentifier parses an AGNTCY schema identifier string
 func ParseSchemaIdentifier(schemaStr string) (*SchemaIdentifier, error) {
 	if schemaStr == "" {
@@ -124,7 +127,6 @@ func ParseSchemaIdentifier(schemaStr string) (*SchemaIdentifier, error) {
 	}
 
 	// AGNTCY schema format: agntcy:domain.entity.version
-	schemaRegex := regexp.MustCompile(`^agntcy:([a-zA-Z0-9_-]+)\.([a-zA-Z0-9_-]+)\.(v[0-9]+)$`)
 	matches := schemaRegex.FindStringSubmatch(schemaStr)
 
 	if len(matches) != 4 {

--- a/internal/validation/validator.go
+++ b/internal/validation/validator.go
@@ -435,25 +435,29 @@ func (v *Validator) isValidEmail(email string) bool {
 	return err == nil
 }
 
+// Validation patterns compiled once at package load.
+var (
+	urlRegex       = regexp.MustCompile(`^https?://[^\s/$.?#].[^\s]*$`)
+	hashRegex      = regexp.MustCompile(`^(sha256|sha512|md5):[a-fA-F0-9]+$`)
+	schemaFmtRegex = regexp.MustCompile(`^agntcy:[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+\.v[0-9]+$`)
+)
+
 // isValidURL validates URL format (basic validation)
 func (v *Validator) isValidURL(url string) bool {
 	// Basic URL validation - starts with http:// or https://
-	urlRegex := regexp.MustCompile(`^https?://[^\s/$.?#].[^\s]*$`)
 	return urlRegex.MatchString(url)
 }
 
 // isValidHashFormat validates hash format (algorithm:value)
 func (v *Validator) isValidHashFormat(hash string) bool {
 	// Should be in format "algorithm:hexvalue"
-	hashRegex := regexp.MustCompile(`^(sha256|sha512|md5):[a-fA-F0-9]+$`)
 	return hashRegex.MatchString(hash)
 }
 
 // validateSchemaFormat validates AGNTCY schema identifier format
 func (v *Validator) validateSchemaFormat(schema string) error {
 	// AGNTCY schema format: agntcy:domain.entity.version
-	schemaRegex := regexp.MustCompile(`^agntcy:[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+\.v[0-9]+$`)
-	if !schemaRegex.MatchString(schema) {
+	if !schemaFmtRegex.MatchString(schema) {
 		return fmt.Errorf("schema must be in format 'agntcy:domain.entity.version': %s", schema)
 	}
 


### PR DESCRIPTION
## Summary
- Move `regexp.MustCompile` calls from function bodies to package-level `var` declarations across 5 files, so each pattern compiles once at init rather than on every invocation.
- Affected hot paths: schema parsing, gateway URL validation, domain validation, URL/hash format checks.
- No regex pattern changes — purely a CPU/allocation optimization.
