### PR TITLE
feat: add Helm chart for Kubernetes deployment

### DIFF
--- a/deployment/chart/.helmignore
+++ b/deployment/chart/.helmignore
@@ -1,0 +1,25 @@
+# Patterns to ignore when building Helm packages.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+# Local secrets / certs should never be packaged
+certs/
+*.key
+*.crt

--- a/deployment/chart/Chart.yaml
+++ b/deployment/chart/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: agentry
+description: Agentry - AMTP Gateway for multi-agent workflow orchestration and organizational memory
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+keywords:
+  - amtp
+  - agent
+  - gateway
+  - multi-agent
+  - workflow
+  - orchestration
+home: https://github.com/amtp-protocol/agentry
+sources:
+  - https://github.com/amtp-protocol/agentry
+maintainers:
+  - name: Cong Wang
+    email: xiyou.wangcong@gmail.com
+icon: https://amtp-protocol.org/amtp.png

--- a/deployment/chart/templates/NOTES.txt
+++ b/deployment/chart/templates/NOTES.txt
@@ -1,0 +1,50 @@
+Thank you for installing {{ .Chart.Name }}!
+
+Your AMTP Gateway has been deployed to namespace {{ .Release.Namespace }}.
+
+{{- if .Values.ingress.enabled }}
+You can access the gateway at:
+{{- range .Values.ingress.hosts }}
+  https://{{ .host }}
+{{- end }}
+{{- else if eq .Values.service.type "LoadBalancer" }}
+To get the external IP:
+  kubectl get svc {{ include "agentry.fullname" . }} -n {{ .Release.Namespace }}
+
+{{- else if eq .Values.service.type "NodePort" }}
+To access the gateway:
+  NODE_PORT=$(kubectl get svc {{ include "agentry.fullname" . }} -n {{ .Release.Namespace }} -o jsonpath='{.spec.ports[0].nodePort}')
+  NODE_IP=$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[0].address}')
+  echo "http://$NODE_IP:$NODE_PORT"
+
+{{- else }}
+To access the gateway from within the cluster:
+  {{ include "agentry.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
+
+To port-forward:
+  kubectl port-forward svc/{{ include "agentry.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.targetPort }} -n {{ .Release.Namespace }}
+{{- end }}
+
+{{- if .Values.tls.enabled }}
+⚠️  TLS is enabled. Make sure your TLS certificate is properly configured.
+{{- if not .Values.tls.existingSecret }}
+A self-signed TLS secret has been created. For production, replace it with a proper certificate:
+  kubectl create secret tls {{ include "agentry.tlsSecretName" . }} \
+    --cert=path/to/tls.crt \
+    --key=path/to/tls.key \
+    -n {{ .Release.Namespace }} \
+    --dry-run=client -o yaml | kubectl apply -f -
+{{- end }}
+{{- end }}
+
+Check deployment status:
+  kubectl rollout status deployment/{{ include "agentry.fullname" . }} -n {{ .Release.Namespace }}
+
+View logs:
+  kubectl logs -f deployment/{{ include "agentry.fullname" . }} -n {{ .Release.Namespace }}
+
+{{- if eq .Values.storage.type "database" }}
+⚠️  Database storage is configured. Ensure your database is reachable from the cluster.
+{{- end }}
+
+For more information, visit: https://github.com/amtp-protocol/agentry

--- a/deployment/chart/templates/_helpers.tpl
+++ b/deployment/chart/templates/_helpers.tpl
@@ -1,0 +1,119 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "agentry.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this.
+*/}}
+{{- define "agentry.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "agentry.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "agentry.labels" -}}
+helm.sh/chart: {{ include "agentry.chart" . }}
+{{ include "agentry.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "agentry.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "agentry.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "agentry.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "agentry.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Generate TLS secret name
+*/}}
+{{- define "agentry.tlsSecretName" -}}
+{{- if .Values.tls.existingSecret }}
+{{- .Values.tls.existingSecret }}
+{{- else }}
+{{- printf "%s-tls" (include "agentry.fullname" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Generate admin key secret name
+*/}}
+{{- define "agentry.adminKeySecretName" -}}
+{{- if .Values.auth.adminKeyExistingSecret }}
+{{- .Values.auth.adminKeyExistingSecret }}
+{{- else }}
+{{- printf "%s-admin-key" (include "agentry.fullname" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Generate database connection string secret name
+*/}}
+{{- define "agentry.dbSecretName" -}}
+{{- if .Values.storage.database.connectionStringExistingSecret }}
+{{- .Values.storage.database.connectionStringExistingSecret }}
+{{- else }}
+{{- printf "%s-db" (include "agentry.fullname" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Generate API key salt secret name
+*/}}
+{{- define "agentry.saltSecretName" -}}
+{{- if .Values.auth.apiKeySaltExistingSecret }}
+{{- .Values.auth.apiKeySaltExistingSecret }}
+{{- else }}
+{{- printf "%s-salt" (include "agentry.fullname" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Whether an admin key file should be mounted (existing secret or inline key provided)
+*/}}
+{{- define "agentry.adminKeyEnabled" -}}
+{{- if and .Values.auth.requireAuth (or .Values.auth.adminKeyExistingSecret .Values.auth.adminKey) }}true{{- end }}
+{{- end }}
+
+{{/*
+Return the environment variable style name for container
+*/}}
+{{- define "agentry.envVarPrefix" -}}
+AMTP
+{{- end }}

--- a/deployment/chart/templates/configmap.yaml
+++ b/deployment/chart/templates/configmap.yaml
@@ -1,0 +1,81 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "agentry.fullname" . }}-config
+  labels:
+    {{- include "agentry.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    version: "0.1.0"
+    server:
+      address: {{ .Values.server.address | quote }}
+      domain: {{ .Values.server.domain | quote }}
+      read_timeout: {{ .Values.server.readTimeout | quote }}
+      write_timeout: {{ .Values.server.writeTimeout | quote }}
+      idle_timeout: {{ .Values.server.idleTimeout | quote }}
+    tls:
+      enabled: {{ .Values.tls.enabled }}
+      cert_file: {{ .Values.tls.certFile | quote }}
+      key_file: {{ .Values.tls.keyFile | quote }}
+      min_version: {{ .Values.tls.minVersion | quote }}
+    dns:
+      cache_ttl: {{ .Values.dns.cacheTTL | quote }}
+      timeout: {{ .Values.dns.timeout | quote }}
+      resolvers:
+        {{- range .Values.dns.resolvers }}
+        - {{ . | quote }}
+        {{- end }}
+      mock_mode: {{ .Values.dns.mockMode }}
+      {{- if .Values.dns.mockMode }}
+      {{- if .Values.dns.mockRecords }}
+      mock_records: {{ .Values.dns.mockRecords }}
+      {{- end }}
+      {{- end }}
+      allow_http: {{ .Values.dns.allowHTTP }}
+    message:
+      max_size: {{ .Values.message.maxSize | int64 }}
+      idempotency_ttl: {{ .Values.message.idempotencyTTL | quote }}
+      validation_enabled: {{ .Values.message.validationEnabled }}
+    auth:
+      require_auth: {{ .Values.auth.requireAuth }}
+      methods:
+        {{- range .Values.auth.methods }}
+        - {{ . | quote }}
+        {{- end }}
+      api_key_header: {{ .Values.auth.apiKeyHeader | quote }}
+      admin_api_key_header: {{ .Values.auth.adminApiKeyHeader | quote }}
+      {{- if and .Values.auth.requireAuth (or .Values.auth.adminKeyExistingSecret .Values.auth.adminKey) }}
+      admin_key_file: "/etc/agentry/admin/admin.key"
+      {{- end }}
+    logging:
+      level: {{ .Values.logging.level | quote }}
+      format: {{ .Values.logging.format | quote }}
+    storage:
+      type: {{ .Values.storage.type | quote }}
+      {{- if eq .Values.storage.type "database" }}
+      database:
+        driver: {{ .Values.storage.database.driver | quote }}
+        max_connections: {{ .Values.storage.database.maxConnections }}
+        max_idle_time: {{ .Values.storage.database.maxIdleTime }}
+      {{- end }}
+    {{- if .Values.metrics.enabled }}
+    metrics:
+      enabled: true
+    {{- end }}
+    {{- if .Values.schema.registryType }}
+    schema:
+      registry_type: {{ .Values.schema.registryType | quote }}
+      {{- if eq .Values.schema.registryType "local" }}
+      local_registry:
+        base_path: {{ .Values.schema.localRegistryPath | quote }}
+      {{- else if eq .Values.schema.registryType "http" }}
+      registry:
+        base_url: {{ .Values.schema.registryURL | quote }}
+        {{- if .Values.schema.registryAuthToken }}
+        auth_token: {{ .Values.schema.registryAuthToken | quote }}
+        {{- end }}
+        {{- if .Values.schema.registryTimeout }}
+        timeout: {{ .Values.schema.registryTimeout | quote }}
+        {{- end }}
+      {{- end }}
+    {{- end }}

--- a/deployment/chart/templates/deployment.yaml
+++ b/deployment/chart/templates/deployment.yaml
@@ -1,0 +1,148 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "agentry.fullname" . }}
+  labels:
+    {{- include "agentry.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "agentry.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if and .Values.tls.enabled (not .Values.tls.existingSecret) }}
+        checksum/tls-secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "agentry.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "agentry.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - "--config"
+            - "/etc/agentry/config/config.yaml"
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.targetPort }}
+              protocol: TCP
+          {{- with .Values.healthCheck }}
+          {{- if .livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: {{ .livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: {{ .readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .readinessProbe.failureThreshold }}
+          {{- end }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- $dbEnv := and (eq .Values.storage.type "database") (or .Values.storage.database.connectionStringExistingSecret .Values.storage.database.connectionString) }}
+          {{- $saltEnv := or .Values.auth.apiKeySaltExistingSecret .Values.auth.apiKeySalt }}
+          {{- if or $dbEnv $saltEnv .Values.extraEnv }}
+          env:
+            {{- if $dbEnv }}
+            - name: AMTP_STORAGE_DATABASE_CONNECTION_STRING
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "agentry.dbSecretName" . }}
+                  key: {{ .Values.storage.database.connectionStringSecretKey }}
+            {{- end }}
+            {{- if $saltEnv }}
+            - name: AMTP_AUTH_API_KEY_SALT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "agentry.saltSecretName" . }}
+                  key: {{ .Values.auth.apiKeySaltSecretKey }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/agentry/config
+              readOnly: true
+            {{- if .Values.tls.enabled }}
+            - name: tls
+              mountPath: /etc/agentry/tls
+              readOnly: true
+            {{- end }}
+            {{- if include "agentry.adminKeyEnabled" . }}
+            - name: admin-key
+              mountPath: /etc/agentry/admin
+              readOnly: true
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "agentry.fullname" . }}-config
+        {{- if .Values.tls.enabled }}
+        - name: tls
+          secret:
+            secretName: {{ include "agentry.tlsSecretName" . }}
+        {{- end }}
+        {{- if include "agentry.adminKeyEnabled" . }}
+        - name: admin-key
+          secret:
+            secretName: {{ include "agentry.adminKeySecretName" . }}
+            items:
+              - key: {{ .Values.auth.adminKeySecretKey }}
+                path: admin.key
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deployment/chart/templates/gateway.yaml
+++ b/deployment/chart/templates/gateway.yaml
@@ -1,0 +1,53 @@
+{{- if .Values.gateway.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: {{ include "agentry.fullname" . }}
+  labels:
+    {{- include "agentry.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/resource-policy": keep
+spec:
+  controllerName: gateway.envoyproxy.io/gatewayclass-controller
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ include "agentry.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agentry.labels" . | nindent 4 }}
+spec:
+  gatewayClassName: {{ include "agentry.fullname" . }}
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: {{ .Values.service.port }}
+      allowedRoutes:
+        namespaces:
+          from: Same
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "agentry.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agentry.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    - name: {{ include "agentry.fullname" . }}
+      namespace: {{ .Release.Namespace }}
+  hostnames:
+    {{- range .Values.gateway.hostnames }}
+    - {{ . | quote }}
+    {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ include "agentry.fullname" . }}
+          port: {{ .Values.service.port }}
+{{- end }}

--- a/deployment/chart/templates/hpa.yaml
+++ b/deployment/chart/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "agentry.fullname" . }}
+  labels:
+    {{- include "agentry.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "agentry.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/deployment/chart/templates/ingress.yaml
+++ b/deployment/chart/templates/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "agentry.fullname" . }}
+  labels:
+    {{- include "agentry.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.tls.enabled }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "agentry.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/deployment/chart/templates/pdb.yaml
+++ b/deployment/chart/templates/pdb.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "agentry.fullname" . }}
+  labels:
+    {{- include "agentry.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- else if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "agentry.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/deployment/chart/templates/secret.yaml
+++ b/deployment/chart/templates/secret.yaml
@@ -1,0 +1,63 @@
+{{- if and .Values.tls.enabled (not .Values.tls.existingSecret) }}
+---
+{{- $tlsName := include "agentry.tlsSecretName" . }}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $tlsName }}
+{{- $crt := "" }}
+{{- $key := "" }}
+{{- if and $existing $existing.data (hasKey $existing.data "tls.crt") }}
+{{- /* Reuse the previously generated certificate so upgrades stay stable */ -}}
+{{- $crt = index $existing.data "tls.crt" }}
+{{- $key = index $existing.data "tls.key" }}
+{{- else }}
+{{- $cn := .Values.server.domain | default "agentry.local" }}
+{{- $cert := genSelfSignedCert $cn nil (list $cn) 3650 }}
+{{- $crt = $cert.Cert | b64enc }}
+{{- $key = $cert.Key | b64enc }}
+{{- end }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $tlsName }}
+  labels:
+    {{- include "agentry.labels" . | nindent 4 }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ $crt }}
+  tls.key: {{ $key }}
+{{- end }}
+{{- if and .Values.auth.requireAuth (not .Values.auth.adminKeyExistingSecret) .Values.auth.adminKey }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "agentry.adminKeySecretName" . }}
+  labels:
+    {{- include "agentry.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{ .Values.auth.adminKeySecretKey }}: {{ .Values.auth.adminKey | b64enc }}
+{{- end }}
+{{- if and (eq .Values.storage.type "database") (not .Values.storage.database.connectionStringExistingSecret) .Values.storage.database.connectionString }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "agentry.dbSecretName" . }}
+  labels:
+    {{- include "agentry.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{ .Values.storage.database.connectionStringSecretKey }}: {{ .Values.storage.database.connectionString | b64enc }}
+{{- end }}
+{{- if and (not .Values.auth.apiKeySaltExistingSecret) .Values.auth.apiKeySalt }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "agentry.saltSecretName" . }}
+  labels:
+    {{- include "agentry.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{ .Values.auth.apiKeySaltSecretKey }}: {{ .Values.auth.apiKeySalt | b64enc }}
+{{- end }}

--- a/deployment/chart/templates/service.yaml
+++ b/deployment/chart/templates/service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "agentry.fullname" . }}
+  labels:
+    {{- include "agentry.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      protocol: TCP
+      name: http
+      {{- if and (eq .Values.service.type "NodePort") .Values.service.nodePort }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
+  selector:
+    {{- include "agentry.selectorLabels" . | nindent 4 }}

--- a/deployment/chart/templates/serviceaccount.yaml
+++ b/deployment/chart/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "agentry.serviceAccountName" . }}
+  labels:
+    {{- include "agentry.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: false
+{{- end }}

--- a/deployment/chart/values.yaml
+++ b/deployment/chart/values.yaml
@@ -1,0 +1,305 @@
+# Default values for Agentry Helm Chart
+# This is a YAML-formatted file.
+
+# -- Number of replicas
+replicaCount: 1
+
+# -- Image configuration
+image:
+  repository: agentry/agentry
+  pullPolicy: IfNotPresent
+  # Overrides the image tag (defaults to Chart appVersion)
+  tag: ""
+
+# -- Image pull secrets
+imagePullSecrets: []
+# - name: my-registry-secret
+
+# -- Override the full name of the chart
+nameOverride: ""
+fullnameOverride: ""
+
+# -- ServiceAccount configuration
+serviceAccount:
+  # -- Create a ServiceAccount
+  create: true
+  # -- Annotations for the ServiceAccount
+  annotations: {}
+  # -- ServiceAccount name (defaults to fullname)
+  name: ""
+
+# -- Pod annotations
+podAnnotations: {}
+# -- Pod labels
+podLabels: {}
+
+# -- Pod security context
+podSecurityContext: {}
+  # fsGroup: 2000
+
+# -- Container security context
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 65534
+
+# -----------------------------------------------------------------------------
+# Agentry Server Configuration
+# -----------------------------------------------------------------------------
+
+server:
+  # -- Server listen address (inside container)
+  address: ":8443"
+  # -- Domain name this gateway serves
+  domain: "example.com"
+  # -- Read timeout (Go duration string, e.g., "30s")
+  readTimeout: "30s"
+  # -- Write timeout (Go duration string, e.g., "30s")
+  writeTimeout: "30s"
+  # -- Idle timeout (Go duration string, e.g., "120s")
+  idleTimeout: "120s"
+
+# -----------------------------------------------------------------------------
+# TLS Configuration
+# -----------------------------------------------------------------------------
+
+tls:
+  # -- Enable TLS
+  enabled: true
+  # -- TLS minimum version (e.g., "1.2", "1.3")
+  minVersion: "1.3"
+  # -- Existing Kubernetes TLS secret name (if set, certFile/keyFile are ignored)
+  existingSecret: ""
+  # -- Path to TLS cert file inside container (ignored if existingSecret is set)
+  certFile: "/etc/agentry/tls/tls.crt"
+  # -- Path to TLS key file inside container (ignored if existingSecret is set)
+  keyFile: "/etc/agentry/tls/tls.key"
+
+# -----------------------------------------------------------------------------
+# DNS Discovery Configuration
+# -----------------------------------------------------------------------------
+
+dns:
+  # -- DNS cache TTL (Go duration string)
+  cacheTTL: "5m"
+  # -- DNS query timeout (Go duration string)
+  timeout: "5s"
+  # -- DNS resolvers
+  resolvers:
+    - "8.8.8.8:53"
+    - "1.1.1.1:53"
+  # -- Enable DNS mock mode (for testing)
+  mockMode: false
+  # -- Allow HTTP endpoints in DNS discovery
+  allowHTTP: false
+  # -- Mock DNS records (JSON string, only used when mockMode is true)
+  mockRecords: ""
+
+# -----------------------------------------------------------------------------
+# Message Processing Configuration
+# -----------------------------------------------------------------------------
+
+message:
+  # -- Maximum message size in bytes (default 10MB)
+  maxSize: 10485760
+  # -- Idempotency TTL (Go duration string, default 7 days)
+  idempotencyTTL: "168h"
+  # -- Enable message validation
+  validationEnabled: true
+
+# -----------------------------------------------------------------------------
+# Authentication Configuration
+# -----------------------------------------------------------------------------
+
+auth:
+  # -- Require authentication
+  requireAuth: false
+  # -- Authentication methods
+  methods:
+    - "domain"
+    - "apikey"
+  # -- API key header name
+  apiKeyHeader: "X-API-Key"
+  # -- Admin API key header name
+  adminApiKeyHeader: "X-Admin-Key"
+  # -- Admin API key value (stored in a generated Secret; leave empty to use existingSecret)
+  adminKey: ""
+  # -- Admin API key value (provided via an existing Secret; takes precedence over adminKey)
+  adminKeyExistingSecret: ""
+  # -- Key within the admin secret for the key value
+  adminKeySecretKey: "admin-key"
+  # -- API key salt for hashing (stored in a generated Secret, injected via env)
+  apiKeySalt: ""
+  # -- API key salt provided via an existing Secret (takes precedence over apiKeySalt)
+  apiKeySaltExistingSecret: ""
+  # -- Key within the salt secret for the salt value
+  apiKeySaltSecretKey: "api-key-salt"
+
+# -----------------------------------------------------------------------------
+# Logging Configuration
+# -----------------------------------------------------------------------------
+
+logging:
+  # -- Log level (debug, info, warn, error)
+  level: "info"
+  # -- Log format (json, text)
+  format: "json"
+
+# -----------------------------------------------------------------------------
+# Storage Configuration
+# -----------------------------------------------------------------------------
+
+storage:
+  # -- Storage type (memory, database)
+  type: "memory"
+  # Database config (only used when type is "database")
+  database:
+    # -- Database driver (pgx)
+    driver: "pgx"
+    # -- Database connection string (can reference an existing secret)
+    connectionString: ""
+    # -- Existing secret containing the connection string
+    connectionStringExistingSecret: ""
+    # -- Key within the secret for the connection string
+    connectionStringSecretKey: "connection-string"
+    # -- Max database connections
+    maxConnections: 100
+    # -- Max idle time in seconds
+    maxIdleTime: 300
+
+# -----------------------------------------------------------------------------
+# Schema Management Configuration
+# -----------------------------------------------------------------------------
+
+schema:
+  # -- Schema registry type (database, local, http)
+  registryType: ""
+  # -- Local registry base path (when registryType is local)
+  localRegistryPath: ""
+  # -- HTTP registry URL (when registryType is http)
+  registryURL: ""
+  # -- Registry auth token
+  registryAuthToken: ""
+  # -- Registry timeout (Go duration string)
+  registryTimeout: ""
+
+# -----------------------------------------------------------------------------
+# Metrics Configuration
+# -----------------------------------------------------------------------------
+
+metrics:
+  # -- Enable metrics endpoint
+  enabled: false
+
+# -----------------------------------------------------------------------------
+# Kubernetes Resources
+# -----------------------------------------------------------------------------
+
+# -- Service configuration
+service:
+  type: ClusterIP
+  port: 8443
+  targetPort: 8443
+  # -- Additional Service annotations
+  annotations: {}
+
+# -- Ingress configuration
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+# -----------------------------------------------------------------------------
+# Gateway API Configuration (requires Envoy Gateway installed)
+# -----------------------------------------------------------------------------
+
+gateway:
+  # -- Enable Gateway API resources (GatewayClass, Gateway, HTTPRoute)
+  enabled: false
+  # -- Custom hostnames for the Gateway HTTPRoute
+  hostnames:
+    - "agentry.example.com"
+
+# -- Resource requests and limits
+resources: {}
+  # limits:
+  #   cpu: 500m
+  #   memory: 512Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+# -- Horizontal Pod Autoscaler configuration
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 80
+  targetMemoryUtilizationPercentage: 80
+
+# -- Node selector for pod assignment
+nodeSelector: {}
+
+# -- Tolerations for pod assignment
+tolerations: []
+
+# -- Affinity for pod assignment
+affinity: {}
+
+# -- Topology spread constraints
+topologySpreadConstraints: []
+
+# -- Pod disruption budget
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+  # maxUnavailable: 1
+
+# -- Extra volumes to mount
+extraVolumes: []
+# - name: custom-config
+#   configMap:
+#     name: agentry-custom
+
+# -- Extra volume mounts
+extraVolumeMounts: []
+# - name: custom-config
+#   mountPath: /etc/agentry/custom
+#   readOnly: true
+
+# -- Extra environment variables
+extraEnv: []
+# - name: FOO
+#   value: bar
+
+# -- Health check configuration
+healthCheck:
+  # -- Enable liveness probe
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 10
+    periodSeconds: 30
+    timeoutSeconds: 3
+    failureThreshold: 3
+  # -- Enable readiness probe
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 3
+    failureThreshold: 3


### PR DESCRIPTION
Add deployment/chart/ with a complete Helm chart for deploying Agentry AMTP Gateway on Kubernetes clusters.

Includes:
- Chart.yaml with metadata and dependencies
- values.yaml with comprehensive configuration options
- Templates: deployment, service, ingress, configmap, secret, serviceaccount, hpa, pdb, gateway (Envoy Gateway API), _helpers, NOTES
- Security: TLS certs generated via genSelfSignedCert (not empty files), database connection string injected via Secret + env var, api_key_salt stored in Secret, no plaintext secrets in ConfigMap

Supports TLS, PostgreSQL storage, schema registry, DNS discovery, metrics, HPA autoscaling, pod disruption budgets, and Envoy Gateway.